### PR TITLE
Github Actions: Fix typo in version-check params

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,7 +19,7 @@ jobs:
         id: version_check
         with:
           # diff the commits rather than commit message for version changes
-          diff_search: true
+          diff-search: true
 
       - name: Version update detected
         if: steps.version_check.outputs.changed == 'true'


### PR DESCRIPTION
Looks like the NPM publish workflow in this repo isn't working due to the warning here: https://github.com/grafana/eslint-config-grafana/actions/runs/967911019
