### PR TITLE
Chore: Remove prettier plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ module.exports = {
       version: "detect",
     },
   },
-  plugins: ["jsdoc", "prettier", "@typescript-eslint", "react-hooks"],
+  plugins: ["jsdoc", "@typescript-eslint", "react-hooks"],
   extends: [
     "plugin:react-hooks/recommended",
-    "plugin:prettier/recommended",
     "plugin:react/recommended",
+    "prettier",
   ],
   parser: "@typescript-eslint/parser",
   rules: {
@@ -43,7 +43,6 @@ module.exports = {
     "no-shadow": "off",
     "no-unused-expressions": "off",
     "no-unused-labels": "error",
-    "prettier/prettier": "error",
     radix: "error",
     "sort-keys": "off",
     "spaced-comment": ["off", "always"],

--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
     "eslint": "7.28.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-jsdoc": "37.7.0",
-    "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
-    "prettier": "2.5.1",
     "typescript": "4.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/eslint-config",
-  "version": "2.5.2",
+  "version": "3.0.0",
   "description": "Grafana's ESLint config",
   "keywords": [
     "grafana",

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,13 +503,6 @@ eslint-plugin-jsdoc@37.7.0:
     semver "^7.3.5"
     spdx-expression-parse "^3.0.1"
 
-eslint-plugin-prettier@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
-  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
@@ -669,11 +662,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.2.9:
   version "3.2.11"
@@ -1244,18 +1232,6 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
-
-prettier@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
-  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
The prettier plugin is quite slow, prettier recommend running it [separately to linters](https://prettier.io/docs/en/integrating-with-linters.html). From profiling the Grafana linting command we can see it consumes ~73% of time taken to complete:

BEFORE:

```TIMING=1 yarn eslint . --ext .js,.tsx,.ts
Rule                                       | Time (ms) | Relative
:------------------------------------------|----------:|--------:
prettier/prettier                          | 47121.683 |    73.1%
jsdoc/check-alignment                      |  3051.863 |     4.7%
react/no-deprecated                        |  2758.311 |     4.3%
react/display-name                         |  2591.744 |     4.0%
react/no-direct-mutation-state             |  2117.436 |     3.3%
react/no-string-refs                       |  1578.806 |     2.4%
react/require-render-return                |  1235.619 |     1.9%
@typescript-eslint/naming-convention       |  1076.987 |     1.7%
no-redeclare                               |   320.645 |     0.5%
@typescript-eslint/type-annotation-spacing |   239.294 |     0.4%
```
AFTER:
```
Rule                                       | Time (ms) | Relative
:------------------------------------------|----------:|--------:
jsdoc/check-alignment                      |  3698.093 |    18.0%
react/no-deprecated                        |  3270.812 |    15.9%
react/display-name                         |  3054.202 |    14.9%
react/no-direct-mutation-state             |  2677.127 |    13.0%
react/no-string-refs                       |  1943.171 |     9.5%
react/require-render-return                |  1493.245 |     7.3%
@typescript-eslint/naming-convention       |  1104.044 |     5.4%
no-redeclare                               |   384.001 |     1.9%
jest/no-focused-tests                      |   319.223 |     1.6%
@typescript-eslint/type-annotation-spacing |   230.898 |     1.1%
```
