### PR TITLE
Add no-var rule + bump major version

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = {
     "no-shadow": "off",
     "no-unused-expressions": "off",
     "no-unused-labels": "error",
+    "no-var": "error",
     radix: "error",
     "sort-keys": "off",
     "spaced-comment": ["off", "always"],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/eslint-config",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Grafana's ESLint config",
   "keywords": [
     "grafana",


### PR DESCRIPTION
will throw an error if we try to use `var` anywhere - prefer using either `let` or `const` 