### PR TITLE
CI: Fix publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://npm.pkg.github.com"
           scope: "@grafana"
 


### PR DESCRIPTION
Publishing workflow is currently failing because it's using node 14.