### PR TITLE
Allow member accessibility even for public

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,10 +66,6 @@ module.exports = {
       },
     ],
     "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/explicit-member-accessibility": [
-      "error",
-      { accessibility: "no-public" },
-    ],
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/no-namespace": ["error", { allowDeclarations: false }],
     "@typescript-eslint/no-unused-vars": "off",


### PR DESCRIPTION
With the scenes architecture we heavily use classes (and we use classes heavily already in core Grafana for data sources and other components). 

We do allow protected and private member accessibility but not public, this to me creates unaligned/inconsistent code. 

I think we should allow the public accessibility modifier. I know it is the default behavior, and it does not add any runtime behavior. It does provide great value. 

It makes it super clear that the author actually thought about the intended use the function. When we only allow private/protected it's not always clear for functions that miss this keyword. Maybe the author just forgot? But a function that has the public keyword it becomes much more clear that the function is intended to be used from the outside. 

It also makes code cleaner / and easier to read when all functions have modifiers: 

Our current rules enforce this: 

![image](https://github.com/grafana/eslint-config-grafana/assets/10999/c54b95ba-b2cd-4b3d-9a45-6b70e0204c48)

And does not allow this: 

Here it is very clear that the intent of the author that the method is to be used from outside

![image](https://github.com/grafana/eslint-config-grafana/assets/10999/38febdbe-157c-45d8-bd17-766dd39a4ae2)

Looking at other large typescript code bases they usually allow public keywords. The vscode code base does NOT enforce member accessibility so it's a bit inconsistent (some classes use public on all public methods some classes don't). I think that inconsistency is the only downside. The upside is that developers who want to be clear in the code they write, can and are allowed to. 

