### PR TITLE
Changes for new jsx runtime and bump major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 8.0.0
+
+### Switch to using new JSX runtime
+  - Required for React 19 support
+  - This is a breaking change and will require coordinated updates to other related packages
+    - Requires updating to `@grafana/tsconfig@2.0.0` or specifying `"jsx": "react-jsx",` manually in your tsconfig
+    - Requires updating build tooling
+      - If using esbuild, steps are [here](https://esbuild.github.io/content-types/#auto-import-for-jsx)
+      - If using Babel, steps are [here](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#manual-babel-setup)
+    - Requires running the [React codemod](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports)
+      - this will remove unused React imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.0.0
 
-### Switch to using new JSX runtime
+### Changes to support using the new JSX runtime
   - Required for React 19 support
   - This is a breaking change and will require coordinated updates to other related packages
     - Requires updating to `@grafana/tsconfig@2.0.0` or specifying `"jsx": "react-jsx",` manually in your tsconfig

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
   extends: [
     "plugin:react-hooks/recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "prettier",
   ],
   parser: "@typescript-eslint/parser",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/eslint-config",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Grafana's ESLint config",
   "keywords": [
     "grafana",


### PR DESCRIPTION
- changes needed to support new JSX runtime
- bump major version

prereq for https://github.com/grafana/grafana/pull/88802/

won't merge and release until we're all ready in core as well 👍 