### PR TITLE
Chore: Use get-vault-secrets without exporting env variables

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           repo_secrets: |
             NPM_TOKEN=npm_token:npm_token
+          export_env: false
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,4 +57,4 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1 # zizmor: ignore[unpinned-uses] provided by grafana
         with:
           repo_secrets: |
             NPM_TOKEN=npm_token:npm_token


### PR DESCRIPTION
Moves the usage of get-vault-secrets to use step outputs instead of global env variables