### PR TITLE
chore: switch codeowners to @grafana/grafana-frontend-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
-* @grafana/plugins-platform-frontend
+* @grafana/grafana-frontend-platform


### PR DESCRIPTION
## Summary
- Update `.github/CODEOWNERS` default owners from `@grafana/plugins-platform-frontend` to `@grafana/grafana-frontend-platform`.

We never discussed every single project during the transfer - but for me it makes more sense to live in frontend platform.

## Test plan
- [ ] Verify the new team has access and receives review requests on the next PR