### PR TITLE
chore: disable install scripts by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 yarnPath: .yarn/releases/yarn-4.4.1.cjs
 
+enableScripts: false
+
 nodeLinker: node-modules


### PR DESCRIPTION
## Summary

Disable install scripts by default to mitigate supply-chain risk from malicious post-install hooks in dependencies.

- npm: `ignore-scripts=true` in `.npmrc`
- yarn (berry): `enableScripts: false` in `.yarnrc.yml`

If any dependency genuinely needs to run a lifecycle script, opt it in explicitly.

## Test plan

- [ ] CI passes (install + build + test)
- [ ] No required postinstall behavior is broken