### PR TITLE
chore(deps): pin npm dependencies to exact lockfile versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "CHANGELOG.md"
   ],
   "devDependencies": {
-    "@stylistic/eslint-plugin-ts": "^2.9.0",
-    "@types/eslint": "^9.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.9.0",
-    "@typescript-eslint/parser": "^8.9.0",
-    "eslint": "^9.12.0",
+    "@stylistic/eslint-plugin-ts": "2.9.0",
+    "@types/eslint": "9.6.1",
+    "@typescript-eslint/eslint-plugin": "8.9.0",
+    "@typescript-eslint/parser": "8.9.0",
+    "eslint": "9.38.0",
     "eslint-config-prettier": "9.1.0",
-    "eslint-plugin-jsdoc": "^50.4.1",
-    "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.0",
-    "typescript": "^5.5.0"
+    "eslint-plugin-jsdoc": "50.4.1",
+    "eslint-plugin-react": "7.37.5",
+    "eslint-plugin-react-hooks": "7.0.0",
+    "typescript": "5.6.3"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin-ts": ">=2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,16 +283,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/eslint-config@workspace:."
   dependencies:
-    "@stylistic/eslint-plugin-ts": "npm:^2.9.0"
-    "@types/eslint": "npm:^9.0.0"
-    "@typescript-eslint/eslint-plugin": "npm:^8.9.0"
-    "@typescript-eslint/parser": "npm:^8.9.0"
-    eslint: "npm:^9.12.0"
+    "@stylistic/eslint-plugin-ts": "npm:2.9.0"
+    "@types/eslint": "npm:9.6.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.9.0"
+    "@typescript-eslint/parser": "npm:8.9.0"
+    eslint: "npm:9.38.0"
     eslint-config-prettier: "npm:9.1.0"
-    eslint-plugin-jsdoc: "npm:^50.4.1"
-    eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^7.0.0"
-    typescript: "npm:^5.5.0"
+    eslint-plugin-jsdoc: "npm:50.4.1"
+    eslint-plugin-react: "npm:7.37.5"
+    eslint-plugin-react-hooks: "npm:7.0.0"
+    typescript: "npm:5.6.3"
   peerDependencies:
     "@stylistic/eslint-plugin-ts": ">=2.9.0"
     "@typescript-eslint/eslint-plugin": ">=6.18.0"
@@ -415,7 +415,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin-ts@npm:^2.9.0":
+"@stylistic/eslint-plugin-ts@npm:2.9.0":
   version: 2.9.0
   resolution: "@stylistic/eslint-plugin-ts@npm:2.9.0"
   dependencies:
@@ -428,7 +428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:^9.0.0":
+"@types/eslint@npm:9.6.1":
   version: 9.6.1
   resolution: "@types/eslint@npm:9.6.1"
   dependencies:
@@ -452,7 +452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^8.9.0":
+"@typescript-eslint/eslint-plugin@npm:8.9.0":
   version: 8.9.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.9.0"
   dependencies:
@@ -475,7 +475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^8.9.0":
+"@typescript-eslint/parser@npm:8.9.0":
   version: 8.9.0
   resolution: "@typescript-eslint/parser@npm:8.9.0"
   dependencies:
@@ -1157,7 +1157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^50.4.1":
+"eslint-plugin-jsdoc@npm:50.4.1":
   version: 50.4.1
   resolution: "eslint-plugin-jsdoc@npm:50.4.1"
   dependencies:
@@ -1178,7 +1178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^7.0.0":
+"eslint-plugin-react-hooks@npm:7.0.0":
   version: 7.0.0
   resolution: "eslint-plugin-react-hooks@npm:7.0.0"
   dependencies:
@@ -1193,7 +1193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:^7.37.5":
+"eslint-plugin-react@npm:7.37.5":
   version: 7.37.5
   resolution: "eslint-plugin-react@npm:7.37.5"
   dependencies:
@@ -1245,7 +1245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.12.0":
+"eslint@npm:9.38.0":
   version: 9.38.0
   resolution: "eslint@npm:9.38.0"
   dependencies:
@@ -2788,7 +2788,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.5.0":
+"typescript@npm:5.6.3":
   version: 5.6.3
   resolution: "typescript@npm:5.6.3"
   bin:
@@ -2798,7 +2798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.5.0#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>":
   version: 5.6.3
   resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:


### PR DESCRIPTION
## Summary

Replace semver ranges in `dependencies` and `devDependencies` with the exact versions already resolved in `yarn.lock`. Direct deps will no longer drift across reinstalls. `yarn.lock` descriptor keys are rewritten by `yarn install` to reflect the new specs; **resolved versions are unchanged**.

## :warning: npmMinimalAgeGate skipped

This repo runs yarn 4.4.1, which does not recognize `npmMinimalAgeGate` (introduced in yarn 4.12). The setting is being applied to other plugins-platform yarn repos. **Apply it here after upgrading yarn separately.**

## Test plan
- [ ] CI green
- [ ] `yarn install` produces no further changes