### PR TITLE
ci: pin actions/checkout to SHA

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: master
           persist-credentials: false


### PR DESCRIPTION
Pin `actions/checkout` in `.github/workflows/publish-npm.yml` for grafana/grafana-catalog-team#957