### PR TITLE
chore: add archive notice to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!TIP]
+> [!IMPORTANT]
 > This repository has been archived and the eslint-config package now lives at https://github.com/grafana/plugin-tools.
 
 # grafana-eslint-config

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!TIP]
+> This repository has been archived and the eslint-config package now lives at https://github.com/grafana/plugin-tools.
+
 # grafana-eslint-config
 
 > Grafana's [ESLint](https://eslint.org) config.


### PR DESCRIPTION
Adding a notice to the readme cos we're moving this package over to https://github.com/grafana/plugin-tools/pull/2723 and archiving this repo.