### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "version": "10.0.0",
   "description": "Grafana's ESLint config",
+  "homepage": "https://github.com/grafana/eslint-config-grafana#readme",
   "keywords": [
     "grafana",
     "eslint",
@@ -25,7 +26,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/grafana/eslint-config-grafana.git"
+    "url": "git+https://github.com/grafana/eslint-config-grafana.git"
+  },
+  "bugs": {
+    "url": "https://github.com/grafana/eslint-config-grafana/issues"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- add explicit npm support metadata for the package homepage and issue tracker
- update the repository URL from `http://` to the public `git+https` Git URL
- leave package code, exports, dependencies, version, and package contents unchanged

## Validation
- node metadata assertion for `package.json`
- `yarn install --immutable` (completed with existing peer dependency warnings)
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
